### PR TITLE
chore: provide dev environment for nix users

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1675698036,
+        "narHash": "sha256-BgsQkQewdlQi8gapJN4phpxkI/FCE/2sORBaFcYbp/A=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1046c7b92e908a1202c0f1ba3fc21d19e1cf1b62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, nixpkgs, }: let
+    system = "x86_64-linux";
+    pkgs = nixpkgs.legacyPackages.${system};
+    inherit (pkgs) lib;
+  in {
+    devShells.${system}.default = pkgs.mkShell {
+      packages = lib.attrValues {
+        inherit (pkgs)
+          cargo rustc
+          clippy cargo-edit cargo-tarpaulin
+          cargo-criterion gnuplot;
+      };
+    };
+  };
+}


### PR DESCRIPTION
This PR introduces a QoL feature for Nix-based developers.
Using these files, a reproducible dev environment can be set up with all required dependencies, see https://nixos.org

This approach could also be extended to build binary outputs or be utilized to run tests in ci.